### PR TITLE
Implement RSA public key retrieval and JWKS endpoint

### DIFF
--- a/auth/src/main/java/com/ndhuy/auth/authentication/application/dto/JsonWebKeySetOut.java
+++ b/auth/src/main/java/com/ndhuy/auth/authentication/application/dto/JsonWebKeySetOut.java
@@ -1,0 +1,18 @@
+package com.ndhuy.auth.authentication.application.dto;
+
+import java.util.List;
+
+import com.ndhuy.auth.authentication.domain.model.JsonWebKey;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class JsonWebKeySetOut {
+    private List<JsonWebKey> keys;
+}

--- a/auth/src/main/java/com/ndhuy/auth/authentication/application/rest/RSARestPublic.java
+++ b/auth/src/main/java/com/ndhuy/auth/authentication/application/rest/RSARestPublic.java
@@ -1,0 +1,24 @@
+package com.ndhuy.auth.authentication.application.rest;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ndhuy.auth.authentication.application.dto.JsonWebKeySetOut;
+import com.ndhuy.auth.authentication.application.service.QueryRSASerivce;
+
+import jakarta.annotation.Resource;
+
+@RestController
+@RequestMapping("api/public/rsa")
+public class RSARestPublic {
+    @Resource
+    QueryRSASerivce queryRsa;
+
+    @GetMapping("/.well-known/jwks.json")
+    public ResponseEntity<JsonWebKeySetOut> getJsonWebKeySet() {
+        return ResponseEntity.ok().body(queryRsa.jwks());
+    }
+
+}

--- a/auth/src/main/java/com/ndhuy/auth/authentication/application/service/QueryRSASerivce.java
+++ b/auth/src/main/java/com/ndhuy/auth/authentication/application/service/QueryRSASerivce.java
@@ -1,0 +1,13 @@
+package com.ndhuy.auth.authentication.application.service;
+
+import com.ndhuy.auth.authentication.application.dto.JsonWebKeySetOut;
+
+public interface QueryRSASerivce {
+        /**
+     * Returns the pre-computed JWKS response. This method is optimized for multiple
+     * calls.
+     *
+     * @return The JsonWebKeySetOut containing the JWKS information.
+     */
+    JsonWebKeySetOut  jwks();
+}

--- a/auth/src/main/java/com/ndhuy/auth/authentication/application/service/impl/QueryRSAImpl.java
+++ b/auth/src/main/java/com/ndhuy/auth/authentication/application/service/impl/QueryRSAImpl.java
@@ -1,0 +1,63 @@
+package com.ndhuy.auth.authentication.application.service.impl;
+
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+
+import com.ndhuy.auth.authentication.application.dto.JsonWebKeySetOut;
+import com.ndhuy.auth.authentication.application.service.QueryRSASerivce;
+import com.ndhuy.auth.authentication.domain.model.JsonWebKey;
+
+import jakarta.annotation.Resource;
+
+@Service
+@Scope("singleton")
+public class QueryRSAImpl implements QueryRSASerivce, InitializingBean {
+
+    @Resource
+    RSAPublicKey rsaPublicKey;
+
+    private static final String DEFAULT_SIGNATURE_ALGORITHM = "RS256"; // Hoặc RS384, RS512 tùy cấu hình
+    private JsonWebKeySetOut jwksOut; // Store the result
+
+    /**
+     * Returns the pre-computed JWKS response. This method is optimized for multiple
+     * calls.
+     *
+     * @return The JsonWebKeySetOut containing the JWKS information.
+     */
+    @Override
+    public JsonWebKeySetOut jwks() {
+        return this.jwksOut; // Return the pre-calculated value.
+
+    }
+
+    /**
+     * Called after all necessary dependencies are injected by the container.
+     * This method performs initialization tasks.
+     */
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        generateKeys();
+
+    }
+
+    private void generateKeys() {
+        // Pre-calculate the JWKS output. This is done only once during the bean's
+        // initialization.
+        final String kid = UUID.randomUUID().toString();
+        final JsonWebKey key = new JsonWebKey(
+                "RSA",
+                kid,
+                "sig",
+                Base64.getUrlEncoder().withoutPadding().encodeToString(rsaPublicKey.getModulus().toByteArray()),
+                Base64.getUrlEncoder().withoutPadding().encodeToString(rsaPublicKey.getPublicExponent().toByteArray()),
+                DEFAULT_SIGNATURE_ALGORITHM);
+        this.jwksOut = new JsonWebKeySetOut(List.of(key));
+    }
+}

--- a/auth/src/main/java/com/ndhuy/auth/authentication/domain/model/JsonWebKey.java
+++ b/auth/src/main/java/com/ndhuy/auth/authentication/domain/model/JsonWebKey.java
@@ -1,0 +1,19 @@
+package com.ndhuy.auth.authentication.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class JsonWebKey {
+    private String kty;
+    private String kid;
+    private String use;
+    private String n;
+    private String e;
+    private String alg;
+}


### PR DESCRIPTION
Introduce a new endpoint for retrieving JSON Web Key Sets (JWKS) using RSA public keys. This includes the implementation of necessary service and data transfer objects to support the retrieval and formatting of JWKS.