### PR TITLE
Refactor ABaseEntity to EntityBase for enhanced auditing

### DIFF
--- a/app/src/main/java/com/ndhuy/app/EntityBase.java
+++ b/app/src/main/java/com/ndhuy/app/EntityBase.java
@@ -6,30 +6,47 @@ import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.Version;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter
-@Setter
-public abstract class ABaseEntity {
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class EntityBase {
+    @Getter
+    @Setter
     @CreatedDate
     private Instant createdDate;
+    @Getter
+    @Setter
     @LastModifiedDate
     private Instant lastModifiedDate;
+    @Getter
+    @Setter
     @CreatedBy
     private String createdBy;
+    @Getter
+    @Setter
     @LastModifiedBy
     private String lastModifiedBy;
 
-    private String deletedBy;
-
-    private Instant deletedDate;
-
     private boolean deleted = false;
-
+    @Getter
+    @Setter
     @Version
     private Long version;
+
+
+    public void delete(){
+        this.deleted = true;
+    }
+    public boolean isDeleted() {
+        return deleted;
+    }
 
 }

--- a/app/src/main/java/com/ndhuy/app/SpringSecurityAuditorAwareImpl.java
+++ b/app/src/main/java/com/ndhuy/app/SpringSecurityAuditorAwareImpl.java
@@ -2,22 +2,32 @@ package com.ndhuy.app;
 
 import java.util.Optional;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 
-public class SpringSecurityAuditorAwareImpl implements AuditorAware<User>{
+@Configuration
+@EnableJpaAuditing
+public class SpringSecurityAuditorAwareImpl implements AuditorAware<User> {
 
-    @Override
-    public Optional<User> getCurrentAuditor() {
-  
-      return Optional.ofNullable(SecurityContextHolder.getContext())
-              .map(SecurityContext::getAuthentication)
-              .filter(Authentication::isAuthenticated)
-              .map(Authentication::getPrincipal)
-              .map(User.class::cast);
-    }
-    
+  @Override
+  public Optional<User> getCurrentAuditor() {
+
+    return Optional.ofNullable(SecurityContextHolder.getContext())
+        .map(SecurityContext::getAuthentication)
+        .filter(Authentication::isAuthenticated)
+        .map(Authentication::getPrincipal)
+        .map(User.class::cast);
+  }
+
+  @Bean
+  AuditorAware<User> auditorProvider() {
+    return new SpringSecurityAuditorAwareImpl();
+  }
+
 }


### PR DESCRIPTION
Replace ABaseEntity with EntityBase to improve auditing support and streamline entity management. Enable JPA auditing in the SpringSecurityAuditorAwareImpl class for better tracking of entity changes.